### PR TITLE
option to get marker's cluster

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -84,6 +84,16 @@ function MarkerClusterer(map, opt_markers, opt_options) {
    */
   this.clusters_ = [];
 
+  /**
+   * @type {Object} holding information about every markers cluster
+   */
+  this.markersCluster_ = {};
+
+  /**
+   * @type {Number} Unique markers ID
+   */
+  this.markersUniqueID = 1;
+
   this.sizes = [53, 56, 66, 78, 90];
 
   /**
@@ -353,6 +363,16 @@ MarkerClusterer.prototype.getMaxZoom = function() {
   return this.maxZoom_;
 };
 
+/**
+ * Gets marker's cluster object based on given marker
+ * 
+ * @param  {google.maps.Marker} marker
+ * 
+ * @return {Cluster}
+ */
+MarkerClusterer.prototype.getMarkersCluster = function(marker) {
+  return this.clusters_[this.markersCluster_[marker.uniqueID]];
+};
 
 /**
  *  The function for calculating the cluster icon image.
@@ -435,6 +455,8 @@ MarkerClusterer.prototype.pushMarkerTo_ = function(marker) {
       that.repaint();
     });
   }
+  marker.uniqueID = this.markersUniqueID;
+  this.markersUniqueID++;  
   this.markers_.push(marker);
 };
 
@@ -481,6 +503,7 @@ MarkerClusterer.prototype.removeMarker_ = function(marker) {
   marker.setMap(null);
 
   this.markers_.splice(index, 1);
+  delete this.markersCluster_[marker.uniqueID];
 
   return true;
 };
@@ -668,6 +691,8 @@ MarkerClusterer.prototype.clearMarkers = function() {
 
   // Set the markers a empty array.
   this.markers_ = [];
+	this.markersCluster_ = {};
+  this.markersUniqueID = 1;  
 };
 
 
@@ -690,6 +715,8 @@ MarkerClusterer.prototype.resetViewport = function(opt_hide) {
   }
 
   this.clusters_ = [];
+  this.markersCluster_ = {};
+  this.markersUniqueID = 1;  
 };
 
 /**
@@ -755,6 +782,7 @@ MarkerClusterer.prototype.addToClosestCluster_ = function(marker) {
   var distance = 40000; // Some large number
   var clusterToAddTo = null;
   var pos = marker.getPosition();
+  var clusterIndex = null;
   for (var i = 0, cluster; cluster = this.clusters_[i]; i++) {
     var center = cluster.getCenter();
     if (center) {
@@ -762,6 +790,7 @@ MarkerClusterer.prototype.addToClosestCluster_ = function(marker) {
       if (d < distance) {
         distance = d;
         clusterToAddTo = cluster;
+        clusterIndex = i;
       }
     }
   }
@@ -772,6 +801,11 @@ MarkerClusterer.prototype.addToClosestCluster_ = function(marker) {
     var cluster = new Cluster(this);
     cluster.addMarker(marker);
     this.clusters_.push(cluster);
+    clusterIndex = this.clusters_.length - 1;
+  }
+  
+  if (marker.isAdded) {
+    this.markersCluster_[marker.uniqueID] = clusterIndex;
   }
 };
 
@@ -1305,6 +1339,7 @@ MarkerClusterer.prototype['getExtendedBounds'] =
 MarkerClusterer.prototype['getMap'] = MarkerClusterer.prototype.getMap;
 MarkerClusterer.prototype['getMarkers'] = MarkerClusterer.prototype.getMarkers;
 MarkerClusterer.prototype['getMaxZoom'] = MarkerClusterer.prototype.getMaxZoom;
+MarkerClusterer.prototype['getMarkersCluster'] = MarkerClusterer.prototype.getMarkersCluster;
 MarkerClusterer.prototype['getStyles'] = MarkerClusterer.prototype.getStyles;
 MarkerClusterer.prototype['getTotalClusters'] =
     MarkerClusterer.prototype.getTotalClusters;


### PR DESCRIPTION
Couldn't merge it, manually recreated this PR https://github.com/googlemaps/js-marker-clusterer/pull/109
I'm not entirely sure about the use case of this to be honest. It only works if the marker is actually hidden (shown as part of a cluster). This method can't be used in a visual way, it only returns the cluster if you're looping through the markers manually and then try to find the cluster.

It also adds a bit of overhead. @XmlmXmlmX what's your opinion about this?