### PR TITLE
fetch images from github

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -198,7 +198,7 @@ function MarkerClusterer(map, opt_markers, opt_options) {
  * @type {string}
  * @private
  */
-MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = '../images/m';
+MarkerClusterer.prototype.MARKER_CLUSTER_IMAGE_PATH_ = 'https://raw.githubusercontent.com/gmaps-marker-clusterer/gmaps-marker-clusterer/master/images/m';
 
 
 /**


### PR DESCRIPTION
This is the PR created here https://github.com/googlemaps/js-marker-clusterer/pull/69
I'm not sure we should merge this though. We currently have a relative path, unlike the absolute path which didn't exist anymore. Having the github images would make it easier for beginners as they would only need to copy the JavaScript, but that's pretty much it.

Do we really want this?