### PR TITLE
add module export to support browserify

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1335,3 +1335,5 @@ Cluster.prototype['getMarkers'] = Cluster.prototype.getMarkers;
 ClusterIcon.prototype['onAdd'] = ClusterIcon.prototype.onAdd;
 ClusterIcon.prototype['draw'] = ClusterIcon.prototype.draw;
 ClusterIcon.prototype['onRemove'] = ClusterIcon.prototype.onRemove;
+
+module.exports = MarkerClusterer;


### PR DESCRIPTION
fixes https://github.com/gmaps-marker-clusterer/gmaps-marker-clusterer/issues/8

with this pull request we can write something like this:

```javascript
var MarkerClusterer = require('../src/markerclusterer.js');
var markerCluster = new MarkerClusterer(map, markers, {imagePath: '../images/m'});
```

and then run this:
```bash
browserify app.js -o build.js
```

Including build.js will then run in a browser and allow us to use npm properly in combination with `require`