### PR TITLE
Allow custom draw, hide, show, onAdd, and onRemove methods for ClusterIcon (v2)

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1232,9 +1232,8 @@ ClusterIcon.prototype.onAdd = function () {
  * @ignore
  */
 function defaultClusterOnAdd(clusterIcon) {
-    // Creating DOM Element only if visible, otherwise an empty div will be rendered.
+    clusterIcon.div_ = document.createElement('DIV');
     if (clusterIcon.visible_) {
-        clusterIcon.div_ = document.createElement('DIV');
         var pos = clusterIcon.getPosFromLatLng_(clusterIcon.center_);
         clusterIcon.div_.style.cssText = clusterIcon.createCss(pos);
         clusterIcon.div_.innerHTML = clusterIcon.sums_.text;


### PR DESCRIPTION
Here's another try at pull request #42 

----------------------------------------

As I mentioned in issue #41, I am customizing the look of clusters beyond what can be accomplished with CSS. I'm using SVGs to create a pie/donut chart that shows the proportions of various types of markers in a cluster.

These modifications to the MarkerClusterer allow me to specify my own functions to be used for essential ClusterIcon methods, so I can create/update/destroy the SVGs as necessary.