### PR TITLE
Fixed a bug which did not add a custom class when dynamically adding markers to an existing cluster

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1237,13 +1237,7 @@ function defaultClusterOnAdd(clusterIcon) {
         var pos = clusterIcon.getPosFromLatLng_(clusterIcon.center_);
         clusterIcon.div_.style.cssText = clusterIcon.createCss(pos);
         clusterIcon.div_.innerHTML = clusterIcon.sums_.text;
-        var markerClusterer = clusterIcon.cluster_.getMarkerClusterer();
-
-        if (markerClusterer.cssClass_) {
-            clusterIcon.div_.className = markerClusterer.cssClass_ + ' ' + markerClusterer.cssDefaultClass_ + clusterIcon.setIndex_;
-        } else {
-            clusterIcon.div_.className = markerClusterer.cssDefaultClass_ + clusterIcon.setIndex_;
-        }
+        clusterIcon.addClass();
     }
 
     var panes = clusterIcon.getPanes();
@@ -1352,6 +1346,7 @@ ClusterIcon.prototype.hide = function() {
 function defaultClusterHide(clusterIcon) {
     if (clusterIcon.div_) {
         clusterIcon.div_.style.display = 'none';
+        clusterIcon.div_.className = '';
     }
     clusterIcon.visible_ = false;
 }
@@ -1378,6 +1373,7 @@ function defaultClusterShow(clusterIcon) {
         var pos = clusterIcon.getPosFromLatLng_(clusterIcon.center_);
         clusterIcon.div_.style.cssText = clusterIcon.createCss(pos);
         clusterIcon.div_.style.display = '';
+        clusterIcon.addClass();
     }
     clusterIcon.visible_ = true;
 }
@@ -1518,6 +1514,20 @@ ClusterIcon.prototype.createCss = function(pos) {
 
     return style.join('');
 };
+
+/**
+ * Set the class for the cluster icon
+ * @ignore
+ */
+ClusterIcon.prototype.addClass = function() {
+    var markerClusterer = this.cluster_.getMarkerClusterer();
+
+    if (markerClusterer.cssClass_) {
+        this.div_.className = markerClusterer.cssClass_ + ' ' + markerClusterer.cssDefaultClass_ + this.setIndex_;
+    } else {
+        this.div_.className = markerClusterer.cssDefaultClass_ + this.setIndex_;
+    }
+}
 
 
 // Export Symbols for Closure


### PR DESCRIPTION
I had a problem when adding markers to an existing cluster. If the cluster only contained a single item the "icon" property would be used. When adding an item to the cluster and thus increasing the size of the cluster, the "icon" property would be ignored and the custom cluster styling would be added. However when using a custom class a very minimal set of styling would be added, but the custom class attribute would not be appended to the tag causing the cluster to be invisible. This small fix should remedy that.