### PR TITLE
Adding a customStyles setting to be used by the ClusterIcon class.

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -61,6 +61,8 @@
  *       'backgroundPosition': (string) The position of the backgound x, y.
  *       'iconAnchor': (Array) The anchor position of the icon x, y.
  *       'cssClass': (string) One or more CSS class for styling this marker.
+ *     'customStyles': (Array) An array of strings representing custom styles to 
+ *                     append to the ClusterIcon
  *     'onMouseoverCluster': (function) The event handler used for onmouseover
  *                           each cluster
  *     'onMouseoutCluster': (function) The event handler used for onmouseout
@@ -158,6 +160,8 @@ function MarkerClusterer(map, opt_markers, opt_options) {
     this.maxZoom_ = options['maxZoom'] || null;
 
     this.styles_ = options['styles'] || [];
+
+    this.customStyles_ = options['customStyles'] || [];
 
     this.cssClass_ = options['cssClass'] || null;
 
@@ -375,6 +379,25 @@ MarkerClusterer.prototype.setStyles = function(styles) {
  */
 MarkerClusterer.prototype.getStyles = function() {
     return this.styles_;
+};
+
+/**
+ *  Sets the custom styles to be used in the cluster icon.
+ *
+ *  @param {Object} styles The style to set.
+ */
+MarkerClusterer.prototype.setCustomStyles = function(customStyles) {
+    this.customStyles_ = customStyles;
+};
+
+
+/**
+ *  Gets the custom styles used in the cluster icon.
+ *
+ *  @return {Object} The styles object.
+ */
+MarkerClusterer.prototype.getCustomStyles = function() {
+    return this.customStyles_;
 };
 
 
@@ -1510,6 +1533,10 @@ ClusterIcon.prototype.createCss = function(pos) {
 
     } else {
         style.push('top:' + pos.y + 'px; left:' + pos.x + 'px;');
+        var customStyles = markerClusterer.getCustomStyles();
+        if (customStyles.length) {
+            style = style.concat(customStyles);
+        }
     }
 
     return style.join('');


### PR DESCRIPTION
## Requirement
I need to display the markers following certain styling rules (opacity, background color, border color, etc), and the clusters should follow the same rules.

I'm creating a `LayerOverlay` to group these markers (and clusters) and each LayerOverlay has its own styling.

## Proposed enhancement
With this addition we now can specify how to display the clusters dinamically, letting the user choose their own color set, opacity, border, etc.

This new setting works in conjuction with the `cssClass` setting.
If both are present, the pin will be rendered including the custom styles (per icon).

## Alternative solution
I could inject a style tag per defined `LayerOverlay` and use it as a the `cssClass`. I thought this was a little harsh thus I wanted to specify it as custom styles per cluster. 

## Example
![image](https://user-images.githubusercontent.com/3626222/29923818-2a68ee8a-8e31-11e7-8747-207fe8ddea91.png)

Please, I would like you to provide feedback whether this a good enhancement or if there is a better alternative.
Thanks.