### PR TITLE
Adding two parameters for Styles

### DIFF
--- a/examples/advanced_example.html
+++ b/examples/advanced_example.html
@@ -48,7 +48,7 @@
         anchor: [16, 0],
         textColor: '#ff00ff',
         textSize: 10,
-        fontFamily: 'OpenSans-Regular, Open Sans',
+        fontFamily: 'Arial,sans-serif',
         fontWeight: 'normal',
       }, {
         url: '../images/people45.png',

--- a/examples/advanced_example.html
+++ b/examples/advanced_example.html
@@ -47,7 +47,9 @@
         width: 35,
         anchor: [16, 0],
         textColor: '#ff00ff',
-        textSize: 10
+        textSize: 10,
+        fontFamily: 'OpenSans-Regular, Open Sans',
+        fontWeight: 'normal',
       }, {
         url: '../images/people45.png',
         height: 45,

--- a/examples/advanced_example.html
+++ b/examples/advanced_example.html
@@ -49,7 +49,7 @@
         textColor: '#ff00ff',
         textSize: 10,
         fontFamily: 'Arial,sans-serif',
-        fontWeight: 'normal',
+        fontWeight: 'bold',
       }, {
         url: '../images/people45.png',
         height: 45,

--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -58,6 +58,8 @@
  *       'anchor': (Array) The anchor position of the label text.
  *       'textColor': (string) The text color.
  *       'textSize': (number) The text size.
+ *       'fontFamily': (string) The text font family.
+ *       'fontWeight': (string) The text font weight.
  *       'backgroundPosition': (string) The position of the backgound x, y.
  *       'iconAnchor': (Array) The anchor position of the icon x, y.
  *     'cssClass': (string) One or more CSS class for styling this marker.
@@ -1445,6 +1447,8 @@ ClusterIcon.prototype.useStyle = function() {
     this.textColor_ = style['textColor'];
     this.anchor_ = style['anchor'];
     this.textSize_ = style['textSize'];
+    this.fontFamily_ = style['fontFamily'];
+    this.fontWeight_ = style['fontWeight'];
     this.backgroundPosition_ = style['backgroundPosition'];
     this.iconAnchor_ = style['iconAnchor'];
     this.setIndex_ = index;
@@ -1503,10 +1507,12 @@ ClusterIcon.prototype.createCss = function(pos) {
 
         var txtColor = this.textColor_ ? this.textColor_ : 'black';
         var txtSize = this.textSize_ ? this.textSize_ : 11;
+        var fontFamily = this.fontFamily_ ? this.fontFamily_ : "Arial,sans-serif";
+        var fontWeight = this.fontWeight_ ? this.fontWeight_ : "bold";
 
         style.push('cursor:pointer; top:' + pos.y + 'px; left:' +
             pos.x + 'px; color:' + txtColor + '; position:absolute; font-size:' +
-            txtSize + 'px; font-family:Arial,sans-serif; font-weight:bold');
+            txtSize + 'px; font-family:' + fontFamily + '; font-weight:' + fontWeight);
 
     } else {
         style.push('top:' + pos.y + 'px; left:' + pos.x + 'px;');


### PR DESCRIPTION
I was previously using MarkerclusterPlus and they have these two options for style. Are quite useful when you have to dynamically create clusters with different styles, allowing these into the **styles** array parameters instead of using **cssClass**, which overrides the **style** array.