### PR TITLE
Check window object exists during SSR build in angular universal apps

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1533,7 +1533,8 @@ ClusterIcon.prototype.addClass = function() {
 // Export Symbols for Closure
 // If you are not going to compile with closure then you can remove the
 // code below.
-window['MarkerClusterer'] = MarkerClusterer;
+if (typeof window != 'undefined')
+    window['MarkerClusterer'] = MarkerClusterer;
 MarkerClusterer.prototype['addMarker'] = MarkerClusterer.prototype.addMarker;
 MarkerClusterer.prototype['addMarkers'] = MarkerClusterer.prototype.addMarkers;
 MarkerClusterer.prototype['clearMarkers'] =


### PR DESCRIPTION
When this library is used in applications based on angular universal, then server side rendering fails. It's because of window object is unknown on server side. This fix will solve these exceptions.