### PR TITLE
google.maps.event.addDomListener is deprecated

### DIFF
--- a/src/markerclusterer.js
+++ b/src/markerclusterer.js
@@ -1271,34 +1271,34 @@ function defaultClusterOnAdd(clusterIcon) {
     var isDragging = false;
     var isMouseDown = false;
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'click', function(event) {
+    clusterIcon.div_.addEventListener('click', function(event) {
         // Only perform click when not preceded by a drag
         if (!isDragging) {
             clusterIcon.triggerClusterClick(event);
         }
     });
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'mousedown', function() {
+    clusterIcon.div_.addEventListener('mousedown', function() {
         isDragging = false;
         isMouseDown = true;
     });
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'mouseup', function() {
+    clusterIcon.div_.addEventListener('mouseup', function() {
         isDragging = false;
         isMouseDown = false;
     });
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'mousemove', function() {
+    clusterIcon.div_.addEventListener('mousemove', function() {
         if (isMouseDown) {
             isDragging = true;
         }
     });
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'mouseover', function(event) {
+    clusterIcon.div_.addEventListener('mouseover', function(event) {
         clusterIcon.triggerClusterMouseover(event);
     });
 
-    google.maps.event.addDomListener(clusterIcon.div_, 'mouseout', function(event) {
+    clusterIcon.div_.addEventListener('mouseout', function(event) {
         clusterIcon.triggerClusterMouseout(event);
     });
 }


### PR DESCRIPTION
Prevents the following console warning:

```
google.maps.event.addDomListener() is deprecated, use the standard addEventListener() method instead: https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener

The feature will continue to work and there is no plan to decommission it.
```